### PR TITLE
fix: #22 내 정보 수정 페이지에서 프로필 사진 업로드 수정

### DIFF
--- a/src/apis/authApi.js
+++ b/src/apis/authApi.js
@@ -4,7 +4,7 @@ const authApi = axios.create({
   baseURL: process.env.REACT_APP_BACKEND_URL,
   timeout: 5000,
   headers: {
-    "Content-Type": "application/json",
+    Accept: "application/json, text/plain, */*",
   },
 });
 

--- a/src/pages/MyInfo/MyInfoEdit.jsx
+++ b/src/pages/MyInfo/MyInfoEdit.jsx
@@ -66,6 +66,7 @@ const AddressButton = styled(Button)`
   background-color: var(--yellow-color1);
   color: var(--black-color);
   margin-bottom: 10px;
+  width: 200px;
 `;
 
 const SaveButton = styled(Button)`
@@ -78,13 +79,17 @@ const MyInfoEdit = () => {
   const { values, handleChange, reset } = useForm({
     nickname: "",
     road_address: "",
+    detail_address: "", // 상세주소 필드 추가
+    profile_image: "", // 프로필 사진 이미지 필드 추가
   });
   const [profileImage, setProfileImage] = useState(null);
   const navigate = useNavigate();
 
+  // 사진은 파일 형태로 업로드
   const handleProfileImageChange = (event) => {
     const file = event.target.files[0];
     setProfileImage(file);
+    handleChange({ target: { name: "profile_image", value: file } });
   };
 
   const handlePostcodeComplete = (data) => {
@@ -99,14 +104,20 @@ const MyInfoEdit = () => {
 
   const handleSave = async () => {
     try {
+      // 프로필 사진을 무조건 업로드하도록 하기
+      if (!profileImage) {
+        alert("프로필 이미지를 업로드해주세요.");
+        return;
+      }
+
       const formData = new FormData();
       formData.append("nickname", values.nickname);
       formData.append("road_address", values.road_address);
+      formData.append("detail_address", values.detail_address);
       formData.append("profile_image", profileImage);
 
-      await authApi.put("/users", formData, {
-        headers: { "Content-Type": "multipart/form-data" },
-      });
+      await authApi.put("/users/", formData); // PUT!!
+
       alert("정보가 성공적으로 변경되었습니다.");
       reset();
       setProfileImage(null);
@@ -159,6 +170,17 @@ const MyInfoEdit = () => {
           placeholder="도로명 주소를 검색하세요."
         />
         <AddressButton text="도로명 주소 찾기" onClick={openPostcode} />
+        <Input
+          label="상세 주소"
+          id="detailAddress"
+          type="text"
+          name="detail_address"
+          placeholder="상세 주소를 입력하세요."
+          value={values.detail_address}
+          onChange={handleChange}
+          style={{ marginBottom: "10px" }}
+        />
+
         <SaveButton text="변경 저장하기" onClick={handleSave} />
       </MyInfoEditContainer>
       <Footer />

--- a/src/pages/MyInfo/MyInfoEdit.jsx
+++ b/src/pages/MyInfo/MyInfoEdit.jsx
@@ -37,6 +37,7 @@ const ImageUpload = styled.div`
   position: relative;
 `;
 
+// 사진 파일 업로드 버튼
 const UploadButton = styled.label`
   font-family: "PretendardM";
   font-size: 14px;
@@ -61,18 +62,31 @@ const FileInput = styled.input`
   display: none;
 `;
 
-const AddressButton = styled(Button)`
-  margin-top: 10px;
-  background-color: var(--yellow-color1);
-  color: var(--black-color);
+// 도로명 주소 검색 컨테이너 추가
+const AddressContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
   margin-bottom: 10px;
-  width: 200px;
 `;
 
+// 도로명 주소 찾기를 위한 검색용 버튼
+const AddressButton = styled(Button)`
+  background-color: var(--yellow-color1);
+  color: var(--black-color);
+  width: 225px;
+`;
+
+// 변경 저장하기 버튼
 const SaveButton = styled(Button)`
   width: 100%;
   background-color: var(--yellow-color2);
   color: var(--black-color);
+  margin-bottom: 10px;
+`;
+
+const StyledInput = styled(Input)`
+  margin-bottom: 10px;
 `;
 
 const MyInfoEdit = () => {
@@ -149,7 +163,7 @@ const MyInfoEdit = () => {
           </UploadButton>
         </ImageUpload>
 
-        <Input
+        <StyledInput
           label="닉네임"
           id="nickname"
           type="text"
@@ -157,20 +171,22 @@ const MyInfoEdit = () => {
           placeholder="변경할 닉네임을 입력하세요."
           value={values.nickname}
           onChange={handleChange}
-          style={{ marginBottom: "10px" }}
         />
 
-        <Input
-          label="도로명 주소"
-          id="roadAddress"
-          type="text"
-          name="road_address"
-          value={values.road_address}
-          readOnly
-          placeholder="도로명 주소를 검색하세요."
-        />
-        <AddressButton text="도로명 주소 찾기" onClick={openPostcode} />
-        <Input
+        <AddressContainer>
+          <StyledInput
+            label="도로명 주소"
+            id="roadAddress"
+            type="text"
+            name="road_address"
+            value={values.road_address}
+            readOnly
+            placeholder="도로명 주소를 검색하세요."
+          />
+          <AddressButton text="도로명 주소 찾기" onClick={openPostcode} />
+        </AddressContainer>
+
+        <StyledInput
           label="상세 주소"
           id="detailAddress"
           type="text"
@@ -178,7 +194,6 @@ const MyInfoEdit = () => {
           placeholder="상세 주소를 입력하세요."
           value={values.detail_address}
           onChange={handleChange}
-          style={{ marginBottom: "10px" }}
         />
 
         <SaveButton text="변경 저장하기" onClick={handleSave} />


### PR DESCRIPTION
## #️⃣연관된 이슈
> #22

## 📝작업 내용
- authApi 파일에서 application/json 요청만 허용했던 헤더를 수정하여 프로필 사진이 파일 형식으로 제대로 업로드 될 수 있도록 했습니다.
- 또한 도로명 주소와 더불어 상세주소를 입력할 수 있도록 필드를 추가하였습니다!

### 스크린샷 (선택)
![2024-07-20 18 35 46](https://github.com/user-attachments/assets/d50be06b-a315-4a4a-86e7-885dbcbc74da)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
