### PR TITLE
Feat: #63 산책 시작전, 산책중, 산책완료 페이지 구현

### DIFF
--- a/src/components/Map/Map2.jsx
+++ b/src/components/Map/Map2.jsx
@@ -1,0 +1,131 @@
+import React, { useState, useEffect, useCallback } from "react";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+import useNewMap from "../../hooks/useNewMap";
+import ToggleButton from "../Button/ToggleButton";
+import MapInfoButton from "../Button/MapInfoButton";
+import { useNavigate, useLocation } from "react-router-dom";
+import DogMoreInfo from "../Dog/DogMoreInfo";
+import IconTagFiltering from "../../assets/icons/icon-tag-filtering.png";
+import "react-tooltip/dist/react-tooltip.css"; // ReactTooltip CSS import
+
+const StyledMap = styled.div`
+  position: relative;
+  width: ${(props) => props.width || "375px"};
+  height: ${(props) => props.height || "555px"};
+  flex-shrink: 0;
+`;
+
+const StyledTagFilteringIcon = styled.div`
+  width: 31px;
+  height: 32px;
+  position: absolute;
+  right: 15px;
+  bottom: 20px;
+  z-index: 100;
+  cursor: pointer;
+  background-image: url(${IconTagFiltering});
+  background-size: cover;
+`;
+
+const Map2 = ({ latitude, longitude, width, height, dogId }) => { // dogId 추가
+  const initialLocation = { latitude, longitude };
+  const [isBoring, setIsBoring] = useState(false);
+  const { mapContainer, map, selectedDog, setSelectedDog } = useNewMap(
+    process.env.REACT_APP_KAKAO_JAVASCRIPT_KEY,
+    initialLocation,
+    dogId, // dogId 전달
+    isBoring,
+  );
+
+  // eslint-disable-next-line no-unused-vars
+  const [positionArr, setPositionArr] = useState([]); // 위치 배열
+
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [isMapInfo, setIsMapInfo] = useState(location.pathname === "/map-info");
+
+  const handleToggle = useCallback((newToggled) => {
+    setIsBoring(newToggled);
+  }, []);
+
+  const onClickTagFilteringIcon = useCallback(() => {
+    navigate("/map-tag");
+  }, [navigate]);
+
+  const handleMapInfoClick = useCallback(() => {
+    setIsMapInfo((prev) => !prev);
+  }, []);
+
+  const handleCloseTooltip = useCallback(() => {
+    setSelectedDog(null);
+  }, [setSelectedDog]);
+
+  // 라인을 그리는 함수
+  const makeLine = useCallback(
+    (position) => {
+      let linePath = position;
+
+      var polyline = new window.kakao.maps.Polyline({
+        path: linePath,
+        strokeWeight: 5,
+        strokeColor: "#ff0000",
+        strokeOpacity: 0.7,
+        strokeStyle: "solid",
+      });
+
+      // 지도에 선을 표시합니다
+      polyline.setMap(map);
+    },
+    [map],
+  );
+
+  // 라인을 그리기 위한 좌표 배열을 만들어주는 함수
+  const setLinePathArr = useCallback(
+    (position) => {
+      const moveLatLon = new window.kakao.maps.LatLng(
+        position.coords.latitude,
+        position.coords.longitude,
+      );
+      setPositionArr((prevArr) => {
+        const newPosition = [...prevArr, moveLatLon];
+        makeLine(newPosition);
+        return newPosition;
+      });
+    },
+    [makeLine],
+  );
+
+  useEffect(() => {
+    if (map) {
+      const interval = setInterval(() => {
+        navigator.geolocation.getCurrentPosition(setLinePathArr);
+      }, 5000);
+
+      return () => {
+        clearInterval(interval);
+      };
+    }
+  }, [map, setLinePathArr]);
+
+  return (
+    <StyledMap ref={mapContainer} width={width} height={height}>
+      <ToggleButton onToggle={handleToggle} />
+      <MapInfoButton isMapInfo={isMapInfo} onClick={handleMapInfoClick} />
+      <StyledTagFilteringIcon onClick={onClickTagFilteringIcon} />
+      {selectedDog && (
+        <DogMoreInfo dogId={selectedDog.id} onClose={handleCloseTooltip} />
+      )}
+    </StyledMap>
+  );
+};
+
+Map2.propTypes = { // 수정된 부분
+  latitude: PropTypes.number.isRequired,
+  longitude: PropTypes.number.isRequired,
+  width: PropTypes.string,
+  height: PropTypes.string,
+  dogId: PropTypes.string.isRequired, // dogId PropTypes 추가
+};
+
+export default Map2;

--- a/src/hooks/useNewMap.js
+++ b/src/hooks/useNewMap.js
@@ -1,0 +1,145 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+import { getCoordinates } from "../apis/geolocation";
+import { getDogInfo } from "../apis/getDogInfo";
+
+const useNewMap = (appKey, initialLocation, dogId, isBoring = false) => {
+  const mapContainer = useRef(null);
+  const [map, setMap] = useState(null);
+  const [currentLocation, setCurrentLocation] = useState(initialLocation); // 현재 위치
+  const [dogMarker, setDogMarker] = useState(null); // 강아지 마커 상태 추가
+  const [selectedDog, setSelectedDog] = useState(null); // 선택된 강아지 상태 추가
+  // eslint-disable-next-line no-unused-vars
+  const [positionArr, setPositionArr] = useState([]); // 위치 배열 상태 추가
+
+  const makeLine = useCallback(
+    (position) => {
+      let linePath = position;
+
+      var polyline = new window.kakao.maps.Polyline({
+        path: linePath,
+        strokeWeight: 5,
+        strokeColor: "#FFAE00",
+        strokeOpacity: 0.7,
+        strokeStyle: "solid",
+      });
+
+      // 지도에 선을 표시합니다
+      polyline.setMap(map);
+    },
+    [map],
+  );
+
+  const setLinePathArr = useCallback(
+    (position) => {
+      const moveLatLon = new window.kakao.maps.LatLng(
+        position.coords.latitude,
+        position.coords.longitude,
+      );
+      setPositionArr((prevArr) => {
+        const newPosition = [...prevArr, moveLatLon];
+        makeLine(newPosition);
+        return newPosition;
+      });
+    },
+    [makeLine],
+  );
+
+  useEffect(() => {
+    const loadKakaoMap = () => {
+      if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition(({ coords }) => {
+          setCurrentLocation({
+            latitude: coords.latitude,
+            longitude: coords.longitude,
+          });
+        });
+      } else {
+        console.error("현재 브라우저에서는 현 위치를 불러올 수 없어요.");
+      }
+    };
+
+    const createScript = () => {
+      const script = document.createElement("script");
+      script.async = true;
+      script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${appKey}&libraries=services,clusterer,drawing&autoload=false`;
+      document.head.appendChild(script);
+      script.onload = initializeMap;
+      return script;
+    };
+
+    const initializeMap = () => {
+      window.kakao.maps.load(() => {
+        loadKakaoMap();
+        if (mapContainer.current) {
+          const options = {
+            center: new window.kakao.maps.LatLng(
+              currentLocation.latitude,
+              currentLocation.longitude,
+            ),
+            level: 7,
+          };
+          const mapInstance = new window.kakao.maps.Map(
+            mapContainer.current,
+            options,
+          );
+          setMap(mapInstance);
+        }
+      });
+    };
+
+    const script = createScript();
+
+    return () => {
+      document.head.removeChild(script);
+    };
+  }, [appKey]);
+
+  useEffect(() => {
+    const fetchDogInfo = async () => {
+      try {
+        const data = await getDogInfo(dogId);
+        const dog = data.dog;
+        const { latitude, longitude } = await getCoordinates(dog.road_address);
+        const markerPosition = new window.kakao.maps.LatLng(latitude, longitude);
+
+        const dogMarkerElement = document.createElement("div");
+        dogMarkerElement.style.width = "50px";
+        dogMarkerElement.style.height = "50px";
+        dogMarkerElement.style.backgroundImage = `url(${dog.image})`;
+        dogMarkerElement.style.backgroundSize = "cover";
+        dogMarkerElement.style.borderRadius = "50%"; // 원형으로 만들기
+
+        const customOverlay = new window.kakao.maps.CustomOverlay({
+          position: markerPosition,
+          content: dogMarkerElement,
+          map: map,
+        });
+
+        setDogMarker(customOverlay);
+
+      } catch (error) {
+        console.error("Error fetching dog info:", error);
+      }
+    };
+
+    if (map) {
+      fetchDogInfo();
+    }
+  }, [map, dogId]);
+
+  useEffect(() => {
+    if (map) {
+      const interval = setInterval(() => {
+        navigator.geolocation.getCurrentPosition(setLinePathArr);
+      }, 5000);
+
+      return () => {
+        clearInterval(interval);
+      };
+    }
+  }, [map, setLinePathArr]);
+
+  return { mapContainer, map, currentLocation, selectedDog, setSelectedDog };
+};
+
+export default useNewMap;

--- a/src/pages/Map/MapStatusStart.jsx
+++ b/src/pages/Map/MapStatusStart.jsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import Header from "../../components/Header/Header";
 import Footer from "../../components/Footer/Footer";
-import Map from "../../components/Map/Map";
+import Map2 from "../../components/Map/Map2";
 import { getDogInfo } from "../../apis/getDogInfo";
 import { getCoordinates } from "../../apis/geolocation";
 
@@ -76,7 +76,7 @@ const MapStatusStart = () => {
   }, []);
 
   const handleStartWalk = () => {
-    navigate(`/map-status/walking/${dogId}`);  // 산책중 페이지로 이동 (라우팅 설정 필요)
+    navigate(`/map-status-walking/${dogId}`); // 산책중 페이지로 이동 (라우팅 설정 필요)
   };
 
   return (
@@ -87,11 +87,12 @@ const MapStatusStart = () => {
           <DogImage src={dogInfo.image} alt={dogInfo.name} />
           <DogName>{dogInfo.name}와 산책을 시작합니다!</DogName>
         </DogInfo>
-        <Map
+        <Map2
           latitude={currentLocation.latitude}
           longitude={currentLocation.longitude}
           width="100%"
           height="300px"
+          dogId={dogId} // dogId 전달
         />
         <StartButton onClick={handleStartWalk}>산책 시작</StartButton>
       </Container>
@@ -101,3 +102,4 @@ const MapStatusStart = () => {
 };
 
 export default MapStatusStart;
+

--- a/src/pages/Map/MapStatusWalking.jsx
+++ b/src/pages/Map/MapStatusWalking.jsx
@@ -3,11 +3,10 @@ import { useParams, useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import Header from "../../components/Header/Header";
 import Footer from "../../components/Footer/Footer";
-import Map from "../../components/Map/Map";
+import Map2 from "../../components/Map/Map2";
 import { getDogInfo } from "../../apis/getDogInfo";
 import { getDistance } from "../../apis/getDistance";
 import { getCoordinates } from "../../apis/geolocation";
-//import SelectRoute from "../../components/Walk/SelectRoute";
 
 const Container = styled.div`
   padding: 20px;
@@ -57,6 +56,13 @@ const Stat = styled.div`
   font-size: 18px;
 `;
 
+// 칼로리 계산 함수
+const get_calories = (distance, time, weight_kg = 70) => {
+  const METs = 3.5;
+  const calories_burned = (time * METs * weight_kg * 3.5) / 200;
+  return calories_burned;
+};
+
 const MapStatusWalking = () => {
   const { dogId } = useParams();
   const navigate = useNavigate();
@@ -66,8 +72,10 @@ const MapStatusWalking = () => {
     longitude: 126.651415033662,
   });
   const [initialLocation, setInitialLocation] = useState(currentLocation);
+  const [previousLocation, setPreviousLocation] = useState(null);
   const [distance, setDistance] = useState(0);
   const [calories, setCalories] = useState(0);
+  const [startTime, setStartTime] = useState(null);
 
   useEffect(() => {
     const fetchDogInfo = async () => {
@@ -88,13 +96,17 @@ const MapStatusWalking = () => {
         const coordinates = await getCoordinates();
         setInitialLocation(coordinates);
         setCurrentLocation(coordinates);
+        setPreviousLocation(coordinates);
+        setStartTime(new Date()); // 산책 시작 시간 설정
       } catch (error) {
         console.error("Error fetching coordinates:", error);
       }
     };
 
     fetchCoordinates();
+  }, []);
 
+  useEffect(() => {
     const watchId = navigator.geolocation.watchPosition(
       (position) => {
         const { latitude, longitude } = position.coords;
@@ -103,14 +115,27 @@ const MapStatusWalking = () => {
           longitude: parseFloat(longitude),
         };
         setCurrentLocation(newCurrentLocation);
-        const dist = getDistance(
-          initialLocation.latitude,
-          initialLocation.longitude,
-          newCurrentLocation.latitude,
-          newCurrentLocation.longitude
-        );
-        setDistance((prev) => prev + dist);
-        setCalories((prev) => prev + dist * 0.04);
+
+        if (previousLocation) {
+          const dist = getDistance(
+            previousLocation.latitude,
+            previousLocation.longitude,
+            newCurrentLocation.latitude,
+            newCurrentLocation.longitude
+          );
+          setDistance((prev) => prev + dist);
+
+          // 시간 계산 (분 단위)
+          const currentTime = new Date();
+          const timeElapsed = (currentTime - startTime) / 60000; // 밀리초를 분으로 변환
+          const totalCalories = get_calories(distance + dist, timeElapsed);
+          setCalories(totalCalories);
+
+          // 로컬 스토리지에 저장
+          localStorage.setItem('walkDistance', (distance + dist).toString());
+          localStorage.setItem('walkCalories', totalCalories.toString());
+        }
+        setPreviousLocation(newCurrentLocation);
       },
       (error) => console.error(error),
       { enableHighAccuracy: true }
@@ -119,10 +144,10 @@ const MapStatusWalking = () => {
     return () => {
       navigator.geolocation.clearWatch(watchId);
     };
-  }, [initialLocation]);
+  }, [previousLocation, startTime, distance]);
 
   const handleEndWalk = () => {
-    navigate(`/map-status/complete/${dogId}`); // 산책 완료 페이지로 이동 (라우팅 설정 해야할듯)
+    navigate(`/map-status-complete/${dogId}`); // 산책 완료 페이지로 이동
   };
 
   return (
@@ -139,11 +164,12 @@ const MapStatusWalking = () => {
             <InfoButton>보호자와 채팅하기</InfoButton>
           </div>
         </DogInfo>
-        <Map
+        <Map2
           latitude={currentLocation.latitude}
           longitude={currentLocation.longitude}
           width="100%"
           height="300px"
+          dogId={dogId} // dogId 전달
         />
         <StopButton onClick={handleEndWalk}>산책 종료</StopButton>
         <Stat>지금까지 {distance.toFixed(1)} km를 이동하셨어요!</Stat>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #63 

## 📝작업 내용

1. Map2.jsx -> Map.jsx 의 지도와 겹치지않는 새로운 지도 컴포넌트 
2. useNewMap.js -> 현재 위치의 지도 렌더링, 마커 표시(마커는 강아지 사진으로)
3. WalkStatusStart.jsx -> 산책 시작전 페이지로 각각의 강아지 ID에 따라 해당 강아지의 사진만 지도에 뜨도록 설정,  산책 시작 버튼 누를시 산책중 페이지로 이동
4. WalkStatusWalking.jsx -> 산책중 페이지로 일정시간이 지나면 자동으로 +1 kcal 증가, 현재 위치에 따라 위치를 이동하면 화면의 이동거리 증가(?) - 이건 아직 테스트를 못해봐서 화면에는 0.0km로 나옴
5. WalkStatusComplete.jsx -> 산책완료 페이지로 산책중에서 증가했던 총 소모 칼로리가 화면에 나타나도록 설정, 만약 위치를 이동해서 화면의 이동거리가 증가된다면 총 산책거리 또한 화면에 나타나도록 설정
 
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 실제로 내가 직접 이동하면서 이동한 거리가 화면에 증가하는게 보여진다면 90% 이상 구현 완료 (아마 한다면 핸드폰으로 해봐야하지 않을까,,,)
각 버튼 누를시 각각의 조건들에 맞는 정보를 보여주는것은 추후에 설정해야함.
아직 스타일 컴포넌트 완벽하게 적용 X
