### PR TITLE
feat: #92 채팅방 프사 추가 및 읽었는 지 조회 가능하도록 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.7.2",
         "chart.js": "^4.4.3",
+        "dayjs": "^1.11.12",
         "dotenv": "^16.4.5",
         "dotenv-webpack": "^8.1.0",
         "file-saver": "^2.0.5",
@@ -7415,6 +7416,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.12",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.12.tgz",
+      "integrity": "sha512-Rt2g+nTbLlDWZTwwrIXjy9MeiZmSDI375FvZs72ngxx8PDC6YXOeR3q5LAuPzjZQxhiWdRKac7RKV+YyQYfYIg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.5",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.7.2",
     "chart.js": "^4.4.3",
+    "dayjs": "^1.11.12",
     "dotenv": "^16.4.5",
     "dotenv-webpack": "^8.1.0",
     "file-saver": "^2.0.5",

--- a/src/apis/chatApi.js
+++ b/src/apis/chatApi.js
@@ -58,3 +58,16 @@ export const getChatRoomMessages = async (roomId) => {
     throw error;
   }
 };
+
+// 특정 사용자의 프로필 사진 확인(user_id)
+export const getProfileImage = async (userId) => {
+  try {
+    const response = await authApi.post("/users/profile-image", {
+      id: userId,
+    });
+    return response.data.image;
+  } catch (error) {
+    console.error("Failed to fetch profile image:", error);
+    throw error;
+  }
+};

--- a/src/components/Chat/Chat.jsx
+++ b/src/components/Chat/Chat.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
+import dayjs from "dayjs";
 
 const ChatRoomContainer = styled.div`
   display: flex;
@@ -9,7 +10,8 @@ const ChatRoomContainer = styled.div`
   padding: 10px;
   margin-bottom: 10px;
   border-radius: 8px;
-  background-color: var(--yellow-color1);
+  background-color: ${(props) =>
+    props.read ? "var(--gray-color1)" : "var(--yellow-color1)"};
   width: 350px;
   font-family: "PretendardM";
   cursor: pointer; /* 클릭 가능하게 커서 변경 */
@@ -26,6 +28,18 @@ const ChatInfo = styled.div`
   display: flex;
   flex-direction: column;
   color: black;
+  flex: 1;
+`;
+
+const ChatHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const NicknameContainer = styled.div`
+  display: flex;
+  align-items: center;
 `;
 
 const Nickname = styled.div`
@@ -33,9 +47,20 @@ const Nickname = styled.div`
   font-size: 18px;
 `;
 
+const RepresentativeBadge = styled.div`
+  background-color: var(--white-color);
+  border-radius: 4px;
+  border: 2px solid var(--yellow-color2);
+  padding: 2px 4px;
+  margin-right: 5px;
+  font-size: 14px;
+  margin-left: 5px;
+`;
+
 const LastMessage = styled.div`
   color: #444444;
-  margin: 5px 0;
+  margin: 10px 0;
+  padding-left: 2px;
 `;
 
 const LastTimeStamp = styled.div`
@@ -44,26 +69,50 @@ const LastTimeStamp = styled.div`
   text-align: right;
 `;
 
+const formatTimestamp = (timestamp) => {
+  if (!timestamp || isNaN(Date.parse(timestamp))) {
+    return "시간 정보 없음";
+  }
+  const now = dayjs();
+  const messageTime = dayjs(timestamp);
+  const diffMinutes = now.diff(messageTime, "minute");
+  const diffHours = now.diff(messageTime, "hour");
+  const diffDays = now.diff(messageTime, "day");
+
+  if (diffMinutes < 60) {
+    return `${diffMinutes}분 전`;
+  } else if (diffHours < 24) {
+    return `${diffHours}시간 전`;
+  } else {
+    return `${diffDays}일 전`;
+  }
+};
+
 const Chat = ({ room }) => {
   const navigate = useNavigate();
-  const lastMessageContent = room.last_message_content || "메시지가 없습니다.";
-  const lastMessageTimestamp =
-    room.last_message_timestamp !== "시간 정보 없음"
-      ? new Date(room.last_message_timestamp).toLocaleString()
-      : "시간 정보 없음";
+  const lastMessageContent =
+    room.last_message_content || "대화 내용이 없습니다.";
+  const lastMessageTimestamp = formatTimestamp(room.last_message_timestamp);
 
   const handleClick = () => {
     navigate(`/chat/rooms/${room.id}`); // room.id로 이동
   };
 
   return (
-    <ChatRoomContainer onClick={handleClick}>
+    <ChatRoomContainer onClick={handleClick} read={room.last_message_read}>
       <ProfileImage
         src={room.other_user_profile_image}
         alt={`${room.other_user_nickname}님의 프로필 사진`}
       />
       <ChatInfo>
-        <Nickname>{room.other_user_nickname}</Nickname>
+        <ChatHeader>
+          <NicknameContainer>
+            {room.other_user_representative && (
+              <RepresentativeBadge>대표</RepresentativeBadge>
+            )}
+            <Nickname>{room.other_user_nickname}</Nickname>
+          </NicknameContainer>
+        </ChatHeader>
         <LastMessage>{lastMessageContent}</LastMessage>
         <LastTimeStamp>{lastMessageTimestamp}</LastTimeStamp>
       </ChatInfo>
@@ -78,6 +127,8 @@ Chat.propTypes = {
     other_user_nickname: PropTypes.string.isRequired,
     last_message_content: PropTypes.string,
     last_message_timestamp: PropTypes.string,
+    last_message_read: PropTypes.bool.isRequired,
+    other_user_representative: PropTypes.bool,
   }).isRequired,
 };
 

--- a/src/pages/Chat/ChatList.jsx
+++ b/src/pages/Chat/ChatList.jsx
@@ -4,6 +4,7 @@ import Header from "../../components/Header/Header";
 import Footer from "../../components/Footer/Footer";
 import authApi from "../../apis/authApi";
 import Chat from "../../components/Chat/Chat";
+import dayjs from "dayjs";
 
 // 채팅방 컴포넌트 리스트
 const ChatRoomList = styled.div`
@@ -26,7 +27,16 @@ const ChatList = () => {
   const [chatRooms, setChatRooms] = useState([]);
   const [loading, setLoading] = useState(true);
 
-  // 유저가 속한 채팅방 목록 반환 - roomId 필요!
+  const formatTimestamp = (timestamp) => {
+    if (!timestamp || isNaN(Date.parse(timestamp))) {
+      return "시간 정보 없음";
+    }
+    const now = dayjs();
+    const messageTime = dayjs(timestamp);
+    const diffHours = now.diff(messageTime, "hour");
+    return `${diffHours}시간 전`;
+  };
+
   useEffect(() => {
     const fetchChatRooms = async () => {
       try {
@@ -35,8 +45,7 @@ const ChatList = () => {
           ...room,
           last_message_content:
             room.last_message_content || "메시지가 없습니다.",
-          last_message_timestamp:
-            room.last_message_timestamp || "시간 정보가 없습니다.",
+          last_message_timestamp: formatTimestamp(room.last_message_timestamp),
         }));
         setChatRooms(rooms);
       } catch (error) {


### PR DESCRIPTION
## #️⃣연관된 이슈
> #92

## 📝작업 내용
- 채팅방 목록에서 상대방 프사 조회 - api도 추가
- 읽은 메시지와 안 읽은 메시지를 다른 색상으로 구분 가능
- 칭호가 있다면 뱃지 추가(추후 상대방 칭호 조회하도록 수정이 필요해요!)
- 프사 fit하게 css수정할게요😅

### 스크린샷 (선택)
![2024-07-30 04 45 57](https://github.com/user-attachments/assets/6b50f5e7-110a-4a2b-bd54-1a7238455c49)


## 💬리뷰 요구사항(선택)
저거 타임스탬프 몇시간 전으로 어떻게 설정할까요..?╰（‵□′）╯
저 라이브러리는 처음 써봐서 잘 몰겠네용